### PR TITLE
Changed github URL to XFW

### DIFF
--- a/applications/services/cli/cli_commands.c
+++ b/applications/services/cli/cli_commands.c
@@ -143,7 +143,7 @@ void cli_command_src(Cli* cli, FuriString* args, void* context) {
     UNUSED(args);
     UNUSED(context);
 
-    printf("https://github.com/RogueMaster/flipperzero-firmware-wPlugins");
+    printf("https://github.com/ClaraCrazy/Flipper-Xtreme");
 }
 
 #define CLI_COMMAND_LOG_RING_SIZE 2048


### PR DESCRIPTION
src command should be pointing to XFW URL IMO

# What's new

- [Proper URL source]

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
