### PR TITLE
XP bar progress to next level, not overall

### DIFF
--- a/applications/services/dolphin/helpers/dolphin_state.c
+++ b/applications/services/dolphin/helpers/dolphin_state.c
@@ -100,11 +100,9 @@ uint8_t dolphin_get_level(int icounter) {
 }
 
 uint32_t dolphin_state_xp_above_last_levelup(int icounter) {
-    if(level_array[0] > icounter) {
-        for(int i = 1; i < 29; ++i) {
-            if(icounter <= level_array[i]) {
-                return level_array[i] - icounter + 1;
-            }
+    for(int i = 1; i < 29; ++i) {
+        if (icounter <= level_array[i]) {
+            return icounter - level_array[i - 1];
         }
     }
     return icounter;

--- a/applications/settings/dolphin_passport/passport.c
+++ b/applications/settings/dolphin_passport/passport.c
@@ -36,16 +36,29 @@ static const Icon* const* portraits_sfw[MOODS_TOTAL] = {
 static const Icon* const* portraits[MOODS_TOTAL] = {portrait_happy, portrait_ok, portrait_bad};
 // static const Icon* const* portraits[MOODS_TOTAL] = {portrait_happy};
 
-static void input_callback(InputEvent* input, void* ctx) {
-    FuriSemaphore* semaphore = ctx;
+typedef struct {
+    FuriSemaphore* semaphore;
+    DolphinStats* stats;
+    ViewPort* view_port;
+    bool progress_total;
+} PassportContext;
+
+static void input_callback(InputEvent* input, void* _ctx) {
+    PassportContext* ctx = _ctx;
+
+    if((input->type == InputTypeShort) && (input->key == InputKeyOk)) {
+        ctx->progress_total = !ctx->progress_total;
+        view_port_update(ctx->view_port);
+    }
 
     if((input->type == InputTypeShort) && (input->key == InputKeyBack)) {
-        furi_semaphore_release(semaphore);
+        furi_semaphore_release(ctx->semaphore);
     }
 }
 
-static void render_callback(Canvas* canvas, void* ctx) {
-    DolphinStats* stats = ctx;
+static void render_callback(Canvas* canvas, void* _ctx) {
+    PassportContext* ctx = _ctx;
+    DolphinStats* stats = ctx->stats;
 
     DesktopSettings* settings = malloc(sizeof(DesktopSettings));
     DESKTOP_SETTINGS_LOAD(settings);
@@ -82,11 +95,16 @@ static void render_callback(Canvas* canvas, void* ctx) {
     uint32_t xp_to_levelup = dolphin_state_xp_to_levelup(stats->icounter);
     uint32_t xp_above_last_levelup = dolphin_state_xp_above_last_levelup(stats->icounter);
     uint32_t xp_for_current_level = xp_to_levelup + xp_above_last_levelup;
+    uint32_t xp_next_level = stats->icounter + xp_to_levelup;
 
     if(stats->level == 30) {
         xp_progress = 0;
     } else {
-        xp_progress = xp_to_levelup * 64 / xp_for_current_level;
+        if (ctx->progress_total) {
+            xp_progress = stats->icounter * 64 / xp_next_level;
+        } else {
+            xp_progress = xp_to_levelup * 64 / xp_for_current_level;
+        }
     }
 
     // multipass
@@ -107,7 +125,11 @@ static void render_callback(Canvas* canvas, void* ctx) {
 
     const char* my_name = furi_hal_version_get_name_ptr();
     snprintf(level_str, 12, "Level: %hu", stats->level);
-    snprintf(xp_str, 12, "%lu/%lu", xp_above_last_levelup, xp_for_current_level);
+    if (ctx->progress_total) {
+        snprintf(xp_str, 12, "%lu/%lu", stats->icounter, xp_next_level);
+    } else {
+        snprintf(xp_str, 12, "%lu/%lu", xp_above_last_levelup, xp_for_current_level);
+    }
     canvas_set_font(canvas, FontSecondary);
     canvas_draw_str(canvas, 58, 10, my_name ? my_name : "Unknown");
     canvas_draw_str(canvas, 58, 22, mood_str);
@@ -121,6 +143,10 @@ static void render_callback(Canvas* canvas, void* ctx) {
     canvas_set_color(canvas, ColorWhite);
     canvas_draw_box(canvas, 123 - xp_progress, 45, xp_progress + 1, 5);
     canvas_set_color(canvas, ColorBlack);
+
+    canvas_draw_icon(canvas, 52, 51, &I_Ok_btn_9x9);
+    canvas_draw_str(canvas, ctx->progress_total ? 37 : 36, 59, ctx->progress_total ? "Lvl" : "Tot");
+
     free(settings);
 }
 
@@ -133,9 +159,14 @@ int32_t passport_app(void* p) {
 
     Dolphin* dolphin = furi_record_open(RECORD_DOLPHIN);
     DolphinStats stats = dolphin_stats(dolphin);
+    PassportContext* ctx = malloc(sizeof(PassportContext));
+    ctx->stats = &stats;
+    ctx->view_port = view_port;
+    ctx->semaphore = semaphore;
+    ctx->progress_total = false;
     furi_record_close(RECORD_DOLPHIN);
-    view_port_draw_callback_set(view_port, render_callback, &stats);
-    view_port_input_callback_set(view_port, input_callback, semaphore);
+    view_port_draw_callback_set(view_port, render_callback, ctx);
+    view_port_input_callback_set(view_port, input_callback, ctx);
     Gui* gui = furi_record_open(RECORD_GUI);
     gui_add_view_port(gui, view_port, GuiLayerFullscreen);
     view_port_update(view_port);
@@ -146,6 +177,7 @@ int32_t passport_app(void* p) {
     view_port_free(view_port);
     furi_record_close(RECORD_GUI);
     furi_semaphore_free(semaphore);
+    free(ctx);
 
     return 0;
 }


### PR DESCRIPTION
# What's new

- Changed `dolphin_state_xp_above_last_levelup()` to *actually* return the xp above last levelup, instead of the current overall xp
- This means the passport xp bar will show progress to next level, not progress counting prior levels
- This makes more sense to me, it tells you how much you need to levelup, but I understand if it was a deliberate decision to have it show the overall progress

EDIT:
- Added a switch to toggle between total stats and current level stats by pressing Ok

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
