### PR TITLE
Add a cycle animations setting

### DIFF
--- a/applications/services/desktop/animations/animation_manager.c
+++ b/applications/services/desktop/animations/animation_manager.c
@@ -197,8 +197,8 @@ static void animation_manager_start_new_idle(AnimationManager* animation_manager
 
     StorageAnimation* new_animation = animation_manager_select_idle_animation(animation_manager);
     animation_manager_replace_current_animation(animation_manager, new_animation);
-    const BubbleAnimation* bubble_animation =
-        animation_storage_get_bubble_animation(animation_manager->current_animation);
+    // const BubbleAnimation* bubble_animation =
+    //     animation_storage_get_bubble_animation(animation_manager->current_animation);
     animation_manager->state = AnimationManagerStateIdle;
     DesktopSettings* settings = malloc(sizeof(DesktopSettings));
     DESKTOP_SETTINGS_LOAD(settings);
@@ -511,8 +511,8 @@ void animation_manager_load_and_continue_animation(AnimationManager* animation_m
                             animation_manager->idle_animation_timer,
                             animation_manager->freezed_animation_time_left);
                     } else {
-                        const BubbleAnimation* animation = animation_storage_get_bubble_animation(
-                            animation_manager->current_animation);
+                        // const BubbleAnimation* animation = animation_storage_get_bubble_animation(
+                        //     animation_manager->current_animation);
                         DesktopSettings* settings = malloc(sizeof(DesktopSettings));
                         DESKTOP_SETTINGS_LOAD(settings);
                         furi_timer_start(

--- a/applications/services/desktop/animations/animation_manager.c
+++ b/applications/services/desktop/animations/animation_manager.c
@@ -118,9 +118,12 @@ static void animation_manager_check_blocking_callback(const void* message, void*
 static void animation_manager_timer_callback(void* context) {
     furi_assert(context);
     AnimationManager* animation_manager = context;
-    if(animation_manager->new_idle_callback) {
+    DesktopSettings* settings = malloc(sizeof(DesktopSettings));
+    DESKTOP_SETTINGS_LOAD(settings);
+    if(!settings->dont_cycle_animations && animation_manager->new_idle_callback) {
         animation_manager->new_idle_callback(animation_manager->context);
     }
+    free(settings);
 }
 
 static void animation_manager_interact_callback(void* context) {

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -322,6 +322,10 @@ int32_t desktop_srv(void* p) {
             DESKTOP_SETTINGS_SAVE(&desktop->settings);
         }
 
+        if(!desktop->settings.cycle_animations_s) {
+            desktop->settings.cycle_animations_s = 3601;
+        }
+
         desktop_main_set_sfw_mode_state(desktop->main_view, desktop->settings.sfw_mode);
 
         scene_manager_next_scene(desktop->scene_manager, DesktopSceneMain);

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -324,6 +324,7 @@ int32_t desktop_srv(void* p) {
 
         if(!desktop->settings.cycle_animations_s) {
             desktop->settings.cycle_animations_s = 3601;
+            DESKTOP_SETTINGS_SAVE(&desktop->settings);
         }
 
         desktop_main_set_sfw_mode_state(desktop->main_view, desktop->settings.sfw_mode);

--- a/applications/services/desktop/desktop_settings.h
+++ b/applications/services/desktop/desktop_settings.h
@@ -64,5 +64,5 @@ typedef struct {
     uint8_t displayBatteryPercentage;
     bool is_sfwmode;
     uint8_t sfw_mode;
-    uint8_t dont_cycle_animations;
+    uint8_t cycle_animations_s;
 } DesktopSettings;

--- a/applications/services/desktop/desktop_settings.h
+++ b/applications/services/desktop/desktop_settings.h
@@ -64,4 +64,5 @@ typedef struct {
     uint8_t displayBatteryPercentage;
     bool is_sfwmode;
     uint8_t sfw_mode;
+    uint8_t dont_cycle_animations;
 } DesktopSettings;

--- a/applications/services/desktop/desktop_settings.h
+++ b/applications/services/desktop/desktop_settings.h
@@ -64,5 +64,5 @@ typedef struct {
     uint8_t displayBatteryPercentage;
     bool is_sfwmode;
     uint8_t sfw_mode;
-    uint8_t cycle_animations_s;
+    uint32_t cycle_animations_s;
 } DesktopSettings;

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -39,13 +39,22 @@ const uint32_t displayBatteryPercentage_value[BATTERY_VIEW_COUNT] = {
 
 uint8_t origBattDisp_value = 0;
 
-#define CYCLE_ANIMATIONS_COUNT 2
+#define CYCLE_ANIMATIONS_COUNT 10
 const char* const cycle_animations_text[CYCLE_ANIMATIONS_COUNT] = {
-    "ON",
     "OFF",
+    "5 M",
+    "10 M",
+    "15 M",
+    "30 M",
+    "1 H",
+    "2 H",
+    "6 H",
+    "12 H",
+    "24 H",
 };
+// Values are offset by 1 so that 0 is not a valid value and desktop.c can detect this to set a default value (3601 / 1 H)
 const uint32_t cycle_animations_value[CYCLE_ANIMATIONS_COUNT] =
-    {0, 1};
+    {1, 301, 601, 901, 1801, 3601, 7201, 21601, 43201, 86401};
 
 static void desktop_settings_scene_start_var_list_enter_callback(void* context, uint32_t index) {
     DesktopSettingsApp* app = context;
@@ -73,7 +82,7 @@ static void desktop_settings_scene_start_cycle_animations_changed(VariableItem* 
     uint8_t index = variable_item_get_current_value_index(item);
 
     variable_item_set_current_value_text(item, cycle_animations_text[index]);
-    app->settings.dont_cycle_animations = auto_lock_delay_value[index];
+    app->settings.cycle_animations_s = cycle_animations_value[index];
 }
 
 void desktop_settings_scene_start_on_enter(void* context) {
@@ -120,13 +129,13 @@ void desktop_settings_scene_start_on_enter(void* context) {
 
     item = variable_item_list_add(
         variable_item_list,
-        "Cycle animations",
+        "Cycle Animations",
         CYCLE_ANIMATIONS_COUNT,
         desktop_settings_scene_start_cycle_animations_changed,
         app);
 
     value_index = value_index_uint32(
-        app->settings.dont_cycle_animations, cycle_animations_value, CYCLE_ANIMATIONS_COUNT);
+        app->settings.cycle_animations_s, cycle_animations_value, CYCLE_ANIMATIONS_COUNT);
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, cycle_animations_text[value_index]);
 

--- a/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
+++ b/applications/settings/desktop_settings/scenes/desktop_settings_scene_start.c
@@ -39,6 +39,14 @@ const uint32_t displayBatteryPercentage_value[BATTERY_VIEW_COUNT] = {
 
 uint8_t origBattDisp_value = 0;
 
+#define CYCLE_ANIMATIONS_COUNT 2
+const char* const cycle_animations_text[CYCLE_ANIMATIONS_COUNT] = {
+    "ON",
+    "OFF",
+};
+const uint32_t cycle_animations_value[CYCLE_ANIMATIONS_COUNT] =
+    {0, 1};
+
 static void desktop_settings_scene_start_var_list_enter_callback(void* context, uint32_t index) {
     DesktopSettingsApp* app = context;
     view_dispatcher_send_custom_event(app->view_dispatcher, index);
@@ -58,6 +66,14 @@ static void desktop_settings_scene_start_battery_view_changed(VariableItem* item
 
     variable_item_set_current_value_text(item, battery_view_count_text[index]);
     app->settings.displayBatteryPercentage = index;
+}
+
+static void desktop_settings_scene_start_cycle_animations_changed(VariableItem* item) {
+    DesktopSettingsApp* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    variable_item_set_current_value_text(item, cycle_animations_text[index]);
+    app->settings.dont_cycle_animations = auto_lock_delay_value[index];
 }
 
 void desktop_settings_scene_start_on_enter(void* context) {
@@ -101,6 +117,18 @@ void desktop_settings_scene_start_on_enter(void* context) {
         BATTERY_VIEW_COUNT);
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, battery_view_count_text[value_index]);
+
+    item = variable_item_list_add(
+        variable_item_list,
+        "Cycle animations",
+        CYCLE_ANIMATIONS_COUNT,
+        desktop_settings_scene_start_cycle_animations_changed,
+        app);
+
+    value_index = value_index_uint32(
+        app->settings.dont_cycle_animations, cycle_animations_value, CYCLE_ANIMATIONS_COUNT);
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, cycle_animations_text[value_index]);
 
     variable_item_list_set_enter_callback(
         variable_item_list, desktop_settings_scene_start_var_list_enter_callback, app);


### PR DESCRIPTION
# What's new

- I noticed it changed animation on its own and was confused, then I read it changed automatically so I thought I'd add a setting
- By default it keeps cycling as normal every 1 hour, but it's not animation dependent anymore, all cycling is settings dependent

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
