### PR TITLE
Fix android app not finding flipper zero device

### DIFF
--- a/applications/services/bt/bt_service/bt.c
+++ b/applications/services/bt/bt_service/bt.c
@@ -388,9 +388,8 @@ static void bt_close_connection(Bt* bt) {
 static inline FuriHalBtProfile get_hal_bt_profile(BtProfile profile) {
     if(profile == BtProfileHidKeyboard) {
         return FuriHalBtProfileHidKeyboard;
-    } else {
-        return FuriHalBtProfileSerial;
     }
+    return FuriHalBtProfileSerial;
 }
 
 static void bt_restart(Bt* bt) {

--- a/firmware/targets/f7/furi_hal/furi_hal_version.c
+++ b/firmware/targets/f7/furi_hal/furi_hal_version.c
@@ -96,7 +96,7 @@ void furi_hal_version_set_custom_name(const char* name) {
         snprintf(
             furi_hal_version.device_name,
             FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
-            "x%s", // Someone tell me why that X is needed
+            "xFlipper %s", // Someone tell me why that X is needed
             name);
 
         furi_hal_version.device_name[0] = AD_TYPE_COMPLETE_LOCAL_NAME;
@@ -109,7 +109,7 @@ static void furi_hal_version_set_name(const char* name) {
         snprintf(
             furi_hal_version.device_name,
             FURI_HAL_VERSION_DEVICE_NAME_LENGTH,
-            "x%s", // Someone tell me why that X is needed
+            "xFlipper %s", // Someone tell me why that X is needed
             furi_hal_version.name);
     } else {
         snprintf(furi_hal_version.device_name, FURI_HAL_VERSION_DEVICE_NAME_LENGTH, "xFlipper");


### PR DESCRIPTION
# What's new

- It should fix https://github.com/ClaraCrazy/Flipper-Xtreme/issues/205
- Little function refactoring
-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
