### PR TITLE
Feature: Custom user set charging cap

### DIFF
--- a/applications/main/xtreme_app/scenes/xtreme_app_scene_misc.c
+++ b/applications/main/xtreme_app/scenes/xtreme_app_scene_misc.c
@@ -54,6 +54,18 @@ static void xtreme_app_scene_misc_lcd_color_changed(VariableItem* item) {
     notification_message(app->notification, &sequence_display_backlight_on);
 }
 
+const char* const charge_cap_names[] =
+    {"50%", "60%", "70%", "80%", "90%", "100%"};
+const int32_t charge_cap_values[COUNT_OF(charge_cap_names)] =
+    {50, 60, 70, 80, 90, 100};
+static void xtreme_app_scene_misc_charge_cap_changed(VariableItem* item) {
+    XtremeApp* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, charge_cap_names[index]);
+    XTREME_SETTINGS()->charge_cap = charge_cap_values[index];
+    app->save_settings = true;
+}
+
 void xtreme_app_scene_misc_on_enter(void* context) {
     XtremeApp* app = context;
     XtremeSettings* xtreme_settings = XTREME_SETTINGS();
@@ -109,6 +121,18 @@ void xtreme_app_scene_misc_on_enter(void* context) {
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, rgb_backlight_get_color_text(value_index));
     variable_item_set_locked(item, !xtreme_settings->rgb_backlight, "Needs RGB\nBacklight!");
+
+    item = variable_item_list_add(
+        var_item_list,
+        "Charge Cap %",
+        COUNT_OF(charge_cap_names),
+        xtreme_app_scene_misc_charge_cap_changed,
+        app);
+    value_index = value_index_uint32(
+        xtreme_settings->anim_speed, charge_cap_values, COUNT_OF(charge_cap_names));
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, charge_cap_names[value_index]);
+
 
     variable_item_list_set_enter_callback(
         var_item_list, xtreme_app_scene_misc_var_item_list_callback, app);

--- a/applications/main/xtreme_app/scenes/xtreme_app_scene_misc.c
+++ b/applications/main/xtreme_app/scenes/xtreme_app_scene_misc.c
@@ -54,10 +54,8 @@ static void xtreme_app_scene_misc_lcd_color_changed(VariableItem* item) {
     notification_message(app->notification, &sequence_display_backlight_on);
 }
 
-const char* const charge_cap_names[] =
-    {"50%", "60%", "70%", "80%", "90%", "100%"};
-const int32_t charge_cap_values[COUNT_OF(charge_cap_names)] =
-    {50, 60, 70, 80, 90, 100};
+const char* const charge_cap_names[] = {"50%", "60%", "70%", "80%", "90%", "100%"};
+const int32_t charge_cap_values[COUNT_OF(charge_cap_names)] = {50, 60, 70, 80, 90, 100};
 static void xtreme_app_scene_misc_charge_cap_changed(VariableItem* item) {
     XtremeApp* app = variable_item_get_context(item);
     uint8_t index = variable_item_get_current_value_index(item);
@@ -132,7 +130,6 @@ void xtreme_app_scene_misc_on_enter(void* context) {
         xtreme_settings->anim_speed, charge_cap_values, COUNT_OF(charge_cap_names));
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, charge_cap_names[value_index]);
-
 
     variable_item_list_set_enter_callback(
         var_item_list, xtreme_app_scene_misc_var_item_list_callback, app);

--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -472,6 +472,21 @@ static void power_check_battery_level_change(Power* power) {
     }
 }
 
+static void power_check_charge_cap(Power* power) {
+    if(power->info.charge >= XTREME_SETTINGS()->charge_cap) {
+        if(!power->info.is_charge_cap_suppressing_charging) { // Suppress charging if charge reaches custom cap
+            power->info.is_charge_cap_suppressing_charging = true;
+            furi_hal_power_suppress_charge_enter();
+        }
+    } else {
+        if(power->info.is_charge_cap_suppressing_charging) { // Start charging again if charge below custom cap
+            power->info.is_charge_cap_suppressing_charging = false;
+            furi_hal_power_suppress_charge_exit();
+        }
+    }
+}
+
+
 void power_trigger_ui_update(Power* power) {
     view_port_update(power->battery_view_port);
 }
@@ -491,6 +506,7 @@ int32_t power_srv(void* p) {
     }
     power_auto_shutdown_arm(power);
     power_update_info(power);
+    power->info.is_charge_cap_suppressing_charging = false; // default false
     furi_record_create(RECORD_POWER, power);
 
     while(1) {
@@ -505,6 +521,9 @@ int32_t power_srv(void* p) {
 
         // Check and notify about battery level change
         power_check_battery_level_change(power);
+
+        // Check charge cap, compare with user setting and suppress/unsuppress charging
+        power_check_charge_cap(power);
 
         // Update battery view port
         if(need_refresh) {

--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -474,18 +474,17 @@ static void power_check_battery_level_change(Power* power) {
 
 static void power_check_charge_cap(Power* power) {
     if(power->info.charge >= XTREME_SETTINGS()->charge_cap) {
-        if(!power->info.is_charge_cap_suppressing_charging) { // Suppress charging if charge reaches custom cap
-            power->info.is_charge_cap_suppressing_charging = true;
+        if(!power->info.is_charge_capped) { // Suppress charging if charge reaches custom cap
+            power->info.is_charge_capped = true;
             furi_hal_power_suppress_charge_enter();
         }
     } else {
-        if(power->info.is_charge_cap_suppressing_charging) { // Start charging again if charge below custom cap
-            power->info.is_charge_cap_suppressing_charging = false;
+        if(power->info.is_charge_capped) { // Start charging again if charge below custom cap
+            power->info.is_charge_capped = false;
             furi_hal_power_suppress_charge_exit();
         }
     }
 }
-
 
 void power_trigger_ui_update(Power* power) {
     view_port_update(power->battery_view_port);
@@ -506,7 +505,7 @@ int32_t power_srv(void* p) {
     }
     power_auto_shutdown_arm(power);
     power_update_info(power);
-    power->info.is_charge_cap_suppressing_charging = false; // default false
+    power->info.is_charge_capped = false; // default false
     furi_record_create(RECORD_POWER, power);
 
     while(1) {

--- a/applications/services/power/power_service/power.h
+++ b/applications/services/power/power_service/power.h
@@ -48,6 +48,7 @@ typedef struct {
 typedef struct {
     bool gauge_is_ok;
     bool is_charging;
+    bool is_charge_cap_suppressing_charging;
 
     float current_charger;
     float current_gauge;

--- a/applications/services/power/power_service/power.h
+++ b/applications/services/power/power_service/power.h
@@ -48,7 +48,7 @@ typedef struct {
 typedef struct {
     bool gauge_is_ok;
     bool is_charging;
-    bool is_charge_cap_suppressing_charging;
+    bool is_charge_capped;
 
     float current_charger;
     float current_gauge;

--- a/lib/xtreme/settings.c
+++ b/lib/xtreme/settings.c
@@ -30,6 +30,7 @@ XtremeSettings xtreme_settings = {
     .bad_bt_remember = false, // OFF
     .butthurt_timer = 21600, // 6 H
     .rgb_backlight = false, // OFF
+    .charge_cap = 100, // 100%
 };
 
 void XTREME_SETTINGS_LOAD() {
@@ -91,6 +92,8 @@ void XTREME_SETTINGS_LOAD() {
         flipper_format_read_int32(file, "butthurt_timer", &x->butthurt_timer, 1);
         flipper_format_rewind(file);
         flipper_format_read_bool(file, "rgb_backlight", &x->rgb_backlight, 1);
+        flipper_format_rewind(file);
+        flipper_format_read_uint32(file, "charge_cap", &x->charge_cap, 1);
     }
     flipper_format_free(file);
     furi_record_close(RECORD_STORAGE);
@@ -127,6 +130,7 @@ void XTREME_SETTINGS_SAVE() {
         flipper_format_write_bool(file, "bad_bt_remember", &x->bad_bt_remember, 1);
         flipper_format_write_int32(file, "butthurt_timer", &x->butthurt_timer, 1);
         flipper_format_write_bool(file, "rgb_backlight", &x->rgb_backlight, 1);
+        flipper_format_write_uint32(file, "charge_cap", &x->charge_cap, 1);
     }
     flipper_format_free(file);
     furi_record_close(RECORD_STORAGE);

--- a/lib/xtreme/settings.c
+++ b/lib/xtreme/settings.c
@@ -29,8 +29,8 @@ XtremeSettings xtreme_settings = {
     .bad_bt = false, // USB
     .bad_bt_remember = false, // OFF
     .butthurt_timer = 21600, // 6 H
-    .rgb_backlight = false, // OFF
     .charge_cap = 100, // 100%
+    .rgb_backlight = false, // OFF
 };
 
 void XTREME_SETTINGS_LOAD() {
@@ -91,9 +91,9 @@ void XTREME_SETTINGS_LOAD() {
         flipper_format_rewind(file);
         flipper_format_read_int32(file, "butthurt_timer", &x->butthurt_timer, 1);
         flipper_format_rewind(file);
-        flipper_format_read_bool(file, "rgb_backlight", &x->rgb_backlight, 1);
-        flipper_format_rewind(file);
         flipper_format_read_uint32(file, "charge_cap", &x->charge_cap, 1);
+        flipper_format_rewind(file);
+        flipper_format_read_bool(file, "rgb_backlight", &x->rgb_backlight, 1);
     }
     flipper_format_free(file);
     furi_record_close(RECORD_STORAGE);
@@ -129,8 +129,8 @@ void XTREME_SETTINGS_SAVE() {
         flipper_format_write_bool(file, "bad_bt", &x->bad_bt, 1);
         flipper_format_write_bool(file, "bad_bt_remember", &x->bad_bt_remember, 1);
         flipper_format_write_int32(file, "butthurt_timer", &x->butthurt_timer, 1);
-        flipper_format_write_bool(file, "rgb_backlight", &x->rgb_backlight, 1);
         flipper_format_write_uint32(file, "charge_cap", &x->charge_cap, 1);
+        flipper_format_write_bool(file, "rgb_backlight", &x->rgb_backlight, 1);
     }
     flipper_format_free(file);
     furi_record_close(RECORD_STORAGE);

--- a/lib/xtreme/xtreme.h
+++ b/lib/xtreme/xtreme.h
@@ -38,6 +38,7 @@ typedef struct {
     bool bad_bt_remember;
     int32_t butthurt_timer;
     bool rgb_backlight;
+    uint32_t charge_cap;
 } XtremeSettings;
 
 void XTREME_SETTINGS_SAVE();

--- a/lib/xtreme/xtreme.h
+++ b/lib/xtreme/xtreme.h
@@ -37,8 +37,8 @@ typedef struct {
     bool bad_bt;
     bool bad_bt_remember;
     int32_t butthurt_timer;
-    bool rgb_backlight;
     uint32_t charge_cap;
+    bool rgb_backlight;
 } XtremeSettings;
 
 void XTREME_SETTINGS_SAVE();


### PR DESCRIPTION
# What's new

This feature will allow users to set a custom charging cap in the Xtreme Settings app.

- New setting `Charge Cap %`.
- New bool `is_charge_cap_suppressing_charging` in `PowerInfo` struct to track if charging has already been suppressed.
- The power service has been extended with a new function `power_check_charge_cap`, which enters/exit charging suppression, when custom charge cap has been reached.

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
