### PR TITLE
Apps: BT Remote: Fix kb combo for Push to Talk / Teams / macOS

### DIFF
--- a/applications/system/hid_app/views/hid_ptt.c
+++ b/applications/system/hid_app/views/hid_ptt.c
@@ -276,7 +276,7 @@ static void hid_ptt_stop_ptt_linux_teamspeak(HidPushToTalk* hid_ptt) {
 
 // teams
 static void hid_ptt_start_ptt_macos_teams(HidPushToTalk* hid_ptt) {
-    hid_hal_keyboard_press(hid_ptt->hid, KEY_MOD_LEFT_GUI | HID_KEYBOARD_SPACEBAR);
+    hid_hal_keyboard_press(hid_ptt->hid, KEY_MOD_LEFT_ALT | HID_KEYBOARD_SPACEBAR);
 }
 static void hid_ptt_start_ptt_linux_teams(HidPushToTalk* hid_ptt) {
     hid_hal_keyboard_press(hid_ptt->hid, KEY_MOD_LEFT_CTRL | HID_KEYBOARD_SPACEBAR);


### PR DESCRIPTION
# What's new

- Fixes the keyboard combination issue with Microsoft Teams on macOS, #544 

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
