### PR TITLE
SubGhz: Display Weather Station temperature in units matching system locale

### DIFF
--- a/lib/subghz/protocols/acurite_592txr.c
+++ b/lib/subghz/protocols/acurite_592txr.c
@@ -285,12 +285,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_acurite_592txr_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderAcurite_592TXR* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -298,7 +299,9 @@ void ws_protocol_decoder_acurite_592txr_get_string(void* context, FuriString* ou
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }
 

--- a/lib/subghz/protocols/acurite_606tx.c
+++ b/lib/subghz/protocols/acurite_606tx.c
@@ -224,12 +224,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_acurite_606tx_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderAcurite_606TX* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -237,6 +238,8 @@ void ws_protocol_decoder_acurite_606tx_get_string(void* context, FuriString* out
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/acurite_609txc.c
+++ b/lib/subghz/protocols/acurite_609txc.c
@@ -224,12 +224,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_acurite_609txc_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderAcurite_609TXC* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 40),
@@ -237,6 +238,8 @@ void ws_protocol_decoder_acurite_609txc_get_string(void* context, FuriString* ou
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/acurite_986.c
+++ b/lib/subghz/protocols/acurite_986.c
@@ -134,7 +134,7 @@ static void ws_protocol_acurite_986_remote_controller(WSBlockGeneric* instance) 
     if(temp & 0x80) {
         temp = -(temp & 0x7F);
     }
-    instance->temp = locale_fahrenheit_to_celsius((float)temp);
+    instance->temp = (float)temp;
     instance->btn = WS_NO_BTN;
     instance->humidity = WS_NO_HUMIDITY;
 }
@@ -256,12 +256,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_acurite_986_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderAcurite_986* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -269,6 +270,8 @@ void ws_protocol_decoder_acurite_986_get_string(void* context, FuriString* outpu
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? locale_fahrenheit_to_celsius(instance->generic.temp) :
+                                    instance->generic.temp),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/ambient_weather.c
+++ b/lib/subghz/protocols/ambient_weather.c
@@ -253,12 +253,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_ambient_weather_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderAmbient_Weather* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -266,6 +267,8 @@ void ws_protocol_decoder_ambient_weather_get_string(void* context, FuriString* o
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/auriol_ahfl.c
+++ b/lib/subghz/protocols/auriol_ahfl.c
@@ -239,12 +239,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_auriol_ahfl_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderAuriol_AHFL* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -252,6 +253,8 @@ void ws_protocol_decoder_auriol_ahfl_get_string(void* context, FuriString* outpu
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/auriol_hg0601a.c
+++ b/lib/subghz/protocols/auriol_hg0601a.c
@@ -233,12 +233,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_auriol_th_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderAuriol_TH* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -246,6 +247,8 @@ void ws_protocol_decoder_auriol_th_get_string(void* context, FuriString* output)
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/gt_wt_02.c
+++ b/lib/subghz/protocols/gt_wt_02.c
@@ -240,12 +240,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_gt_wt_02_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderGT_WT02* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -253,6 +254,8 @@ void ws_protocol_decoder_gt_wt_02_get_string(void* context, FuriString* output) 
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/gt_wt_03.c
+++ b/lib/subghz/protocols/gt_wt_03.c
@@ -315,12 +315,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_gt_wt_03_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderGT_WT03* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -328,6 +329,8 @@ void ws_protocol_decoder_gt_wt_03_get_string(void* context, FuriString* output) 
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/infactory.c
+++ b/lib/subghz/protocols/infactory.c
@@ -271,12 +271,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_infactory_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderInfactory* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -284,6 +285,8 @@ void ws_protocol_decoder_infactory_get_string(void* context, FuriString* output)
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/kedsum_th.c
+++ b/lib/subghz/protocols/kedsum_th.c
@@ -279,12 +279,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_kedsum_th_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderKedsumTH* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -292,6 +293,8 @@ void ws_protocol_decoder_kedsum_th_get_string(void* context, FuriString* output)
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/lacrosse_tx.c
+++ b/lib/subghz/protocols/lacrosse_tx.c
@@ -304,12 +304,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_lacrosse_tx_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderLaCrosse_TX* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -317,6 +318,8 @@ void ws_protocol_decoder_lacrosse_tx_get_string(void* context, FuriString* outpu
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/lacrosse_tx141thbv2.c
+++ b/lib/subghz/protocols/lacrosse_tx141thbv2.c
@@ -290,12 +290,13 @@ SubGhzProtocolStatus ws_protocol_decoder_lacrosse_tx141thbv2_deserialize(
 void ws_protocol_decoder_lacrosse_tx141thbv2_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderLaCrosse_TX141THBv2* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -303,6 +304,8 @@ void ws_protocol_decoder_lacrosse_tx141thbv2_get_string(void* context, FuriStrin
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/nexus_th.c
+++ b/lib/subghz/protocols/nexus_th.c
@@ -313,12 +313,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_nexus_th_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderNexus_TH* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -326,7 +327,9 @@ void ws_protocol_decoder_nexus_th_get_string(void* context, FuriString* output) 
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }
 

--- a/lib/subghz/protocols/thermopro_tx4.c
+++ b/lib/subghz/protocols/thermopro_tx4.c
@@ -236,12 +236,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_thermopro_tx4_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderThermoPRO_TX4* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -249,6 +250,8 @@ void ws_protocol_decoder_thermopro_tx4_get_string(void* context, FuriString* out
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/tx_8300.c
+++ b/lib/subghz/protocols/tx_8300.c
@@ -269,12 +269,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_tx_8300_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderTX_8300* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -282,6 +283,8 @@ void ws_protocol_decoder_tx_8300_get_string(void* context, FuriString* output) {
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }

--- a/lib/subghz/protocols/wendox_w6726.c
+++ b/lib/subghz/protocols/wendox_w6726.c
@@ -284,12 +284,13 @@ SubGhzProtocolStatus
 void ws_protocol_decoder_wendox_w6726_get_string(void* context, FuriString* output) {
     furi_assert(context);
     WSProtocolDecoderWendoxW6726* instance = context;
+    bool locale_is_metric = furi_hal_rtc_get_locale_units() == FuriHalRtcLocaleUnitsMetric;
     furi_string_cat_printf(
         output,
         "%s\r\n%dbit\r\n"
         "Key:0x%lX%08lX\r\n"
         "Sn:0x%lX Ch:%d  Bat:%d\r\n"
-        "Temp:%3.1f C Hum:%d%%",
+        "Temp:%3.1f %c Hum:%d%%",
         instance->generic.protocol_name,
         instance->generic.data_count_bit,
         (uint32_t)(instance->generic.data >> 32),
@@ -297,6 +298,8 @@ void ws_protocol_decoder_wendox_w6726_get_string(void* context, FuriString* outp
         instance->generic.id,
         instance->generic.channel,
         instance->generic.battery_low,
-        (double)instance->generic.temp,
+        (double)(locale_is_metric ? instance->generic.temp :
+                                    locale_celsius_to_fahrenheit(instance->generic.temp)),
+        locale_is_metric ? 'C' : 'F',
         instance->generic.humidity);
 }


### PR DESCRIPTION
# What's new

- Display temperature from Acurite weather stations in Celsius or Fahrenheit corresponding to system settings

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable (I've only actually tested with the Acurite-609TXC, but all four operate similarly)